### PR TITLE
Don't use free variable

### DIFF
--- a/tabulated-list-ext.el
+++ b/tabulated-list-ext.el
@@ -48,8 +48,8 @@
   (save-excursion
     (goto-char (point-min))
     (while (not (eobp))
-      (setq cmd (char-after))
-      (tabulated-list-put-tag (if (eq cmd ?*) "" "*") t))))
+      (let ((cmd (char-after)))
+        (tabulated-list-put-tag (if (eq cmd ?*) "" "*") t)))))
 
 (defun tabulated-list-unmark-all ()
   "Unmark all."


### PR DESCRIPTION
And use local variable instead of free variable.

This also fixes following byte-compile warnings.

```
tabulated-list-ext.el:51:13:Warning: assignment to free variable `cmd'            
tabulated-list-ext.el:52:39:Warning: reference to free variable `cmd'
```
